### PR TITLE
docs: Updating readme to include alternative installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ex: `git commit -m "Add: Added API to urls.py"`
 Installing dependencies that were added to the environment.yml file
 ```
 conda env update environment.yml
-conda activate photoTaggerEnv
+conda activate photoTaggerEnv or source activate photoTaggerEnv
 ```
 Viewing current dependencies installed within an environment
 `conda list`


### PR DESCRIPTION
Updating readme to include an alternative installation command. My system is setup to only work for source activate ... but it can be conda activate .. on other systems