### PR TITLE
build: Tensorflow version update

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - numpy=1.15.2
   - pillow=5.3.0
   - python=3.6.6
-  - tensorflow=1.10
+  - tensorflow=1.11.0


### PR DESCRIPTION
It looks like tensorflow version 1.10 is incompatible with the version of python we're using. 